### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ An attempt to improve the dxvk async patch at https://github.com/jomihaka/dxvk-p
 
 ## Warnings
 
-dxvk-async has had a bit of a history with triggering client-side anti cheats, and as such, may be risky to use inside of multiplayer games.
+dxvk-async could theoretically trigger client-side anti cheats, and as such, may be risky to use inside of multiplayer games.
 If you have been banned because of dxvk-async, please report about it at [this issue here](https://github.com/Sporif/dxvk-async/issues/42) with information about your system (like a neofetch), distribution/OS (BSD, GNU/Linux, etc.), how long it took the ban to take effect, and whether or not you were able to get unbanned. 


### PR DESCRIPTION
As far as I know, there was never a ban that happened due to dxvk_async. What I know of, is just this report on reddit: https://www.reddit.com/r/linux_gaming/comments/9fkuq9/overwatch_avoid_async_option_for_dxvk_banned_for/

The person who created it, later edited the post, mentioning that other people who were not using dxvk_async were also banned. Later, Blizzard apologized for the bans, saying that they were due an error, and everyone was unbanned.

Therefore I suggest to change the wording to reflect this.